### PR TITLE
Fire Dust  patch

### DIFF
--- a/RWBY World of Remnant/Common/Patches/Core/Defs/ThingDefs_Buildings/Buildings.xml
+++ b/RWBY World of Remnant/Common/Patches/Core/Defs/ThingDefs_Buildings/Buildings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+    <Operation Class="PatchOperationAdd">
+        <order>Append</order>
+        <xpath> Defs/ThingDef[defName = "FueledStove"]/comps/li[contains(@Class,'CompProperties_Refuelable')]/fuelFilter/thingDefs |
+                Defs/ThingDef[defName = "WoodFiredGenerator"]/comps/li[contains(@Class,'CompProperties_Refuelable')]/fuelFilter/thingDefs |
+		        Defs/ThingDef[defName = "FueledSmithy"]/comps/li[contains(@Class,'CompProperties_Refuelable')]/fuelFilter/thingDefs |
+		        Defs/ThingDef[defName = "TorchLamp"]/comps/li[contains(@Class,'CompProperties_Refuelable')]/fuelFilter/thingDefs |
+		        Defs/ThingDef[defName = "Campfire"]/comps/li[contains(@Class,'CompProperties_Refuelable')]/fuelFilter/thingDefs</xpath>				
+        <value>
+		    <li>FireDustCrystal</li>
+        </value>
+    </Operation>	
+	
+</Patch>
+


### PR DESCRIPTION
 can be used as fuel, Can be used in wood-fired generators, fueled smithy, fueled stoves, campfires and torches.